### PR TITLE
fix. return resolved/rejected promise after "onStart" callback promis…

### DIFF
--- a/src/lib/BaseStore.js
+++ b/src/lib/BaseStore.js
@@ -43,9 +43,11 @@ export default class BaseStore {
 
     return waitFor
       ?
-      waitFor.then(() => {
-        this.startDo(initiatorId, this.serviceStarter);
-      })
+      new Promise((resolve, reject) => waitFor.then(() => {
+        this.startDo(initiatorId, this.serviceStarter)
+          .then(() => resolve())
+          .catch((error) => reject(error));
+      }))
       :
       this.startDo(initiatorId, this.serviceStarter);
   }


### PR DESCRIPTION
Before this fix `start` method returns resolved promise straight after all its waiters have resolved, not after `onStart` callback has resolved.
